### PR TITLE
Avoid overrunning shell argument list length limits

### DIFF
--- a/proc/Makefile
+++ b/proc/Makefile
@@ -15,7 +15,8 @@ install: $(SUBDIRS)
 	$(foreach dir,$(SUBDIRS), \
 		rm -rf ${LIBDESTDIR}/proc/$(dir); \
 		mkdir -p ${LIBDESTDIR}/proc/$(dir); \
-		cp $(dir)/* ${LIBDESTDIR}/proc/$(dir) 2>>/dev/null; \
+		cp $(dir)/* ${LIBDESTDIR}/proc/$(dir) 2>>/dev/null;)
+	$(foreach dir,$(SUBDIRS), \
 		rm ${LIBDESTDIR}/proc/$(dir)/[p32,pmec]*.S; \
 		rm ${LIBDESTDIR}/proc/$(dir)/Makefile; )
 


### PR DESCRIPTION
Build dir has a very long path on Bamboo and this used to result in 'argument list too long' shell error.